### PR TITLE
Unblock Trend Widget

### DIFF
--- a/mint-adfree.txt
+++ b/mint-adfree.txt
@@ -40,9 +40,6 @@ mint.intuit.com###TopTxnOfferWidget
 ! Recommendations under totals.
 mint.intuit.com###advice-top-container
 
-! Column with ads on the far right.
-mint.intuit.com###txn-column-details-personal
-
 ! Inline ads in transactions.
 mint.intuit.com###TxnOfferWidgetContainer
 


### PR DESCRIPTION
I recommend removing this section, as it blocks the widget for recent spending on the transactions page. I never see an ad there, and without uBlock Origin enabled, I do not see one.