### PR TITLE
Transactions page: updated ad elements

### DIFF
--- a/mint-adfree.txt
+++ b/mint-adfree.txt
@@ -35,13 +35,13 @@ mint.intuit.com###moduleAccounts-investment > .accounts-adv[href^="/investment.e
 ! Transactions page.
 
 ! Ad under totals.
-mint.intuit.com###TxnWelcomeMatContainer
+mint.intuit.com###TopTxnOfferWidgetContainer
 
 ! Recommendations under totals.
 mint.intuit.com###advice-top-container
 
 ! Inline ads in transactions.
-mint.intuit.com###InlineBannerWidgetContainer
+mint.intuit.com###TxnOfferWidgetContainer
 
 
 ! Credit Score page.


### PR DESCRIPTION
Mint's Transactions page ad elements appear to have changed back. 

_(Looks like we essentially need to undo Pull #10.)_

I corrected to use the specific containers:

*  `#TopTxnOfferWidgetContainer` _(Ad under totals.)_
*  `#TxnOfferWidgetContainer` _(Inline ads in transactions.)_