### PR TITLE
Use "investment-new.event" to block investments link

### DIFF
--- a/mint-adfree.txt
+++ b/mint-adfree.txt
@@ -29,7 +29,7 @@ mint.intuit.com###moduleAccounts-bank > .accounts-adv[href^="/save.event"]
 mint.intuit.com###moduleAccounts-credit > .accounts-adv[href^="/save.event"]
 
 ! "Invest now with fewer fees »" under "Investments" account.
-mint.intuit.com###moduleAccounts-investment > .accounts-adv[href^="/investment.event"]
+mint.intuit.com###moduleAccounts-investment > .accounts-adv[href^="/investment-new.event"]
 
 
 ! Transactions page.


### PR DESCRIPTION
Fixes #15.

Uses `investment-new.event` to block this link:

![image](https://user-images.githubusercontent.com/820984/75129733-0eb14780-5690-11ea-8a17-6fb9dcdc8a2a.png)